### PR TITLE
Feature/break nesting block level

### DIFF
--- a/swift-lintcode/Binary Tree/LCDepthTree.swift
+++ b/swift-lintcode/Binary Tree/LCDepthTree.swift
@@ -38,12 +38,12 @@ class LCDepthTree: NSObject {
 
 extension LCDepthTree {
     class func maxDepth(root: LCTreeNode?) -> Int {
-        if root == nil {
+        guard let root = root else {
             return 0
         }
         
-        let left = LCDepthTree.maxDepth(root!.left)
-        let right = LCDepthTree.maxDepth(root!.right)
+        let left = LCDepthTree.maxDepth(root.left)
+        let right = LCDepthTree.maxDepth(root.right)
         
         return max(left, right) + 1
     }

--- a/swift-lintcode/Binary Tree/LCTreeLevelTraversal.swift
+++ b/swift-lintcode/Binary Tree/LCTreeLevelTraversal.swift
@@ -53,14 +53,18 @@ extension LCTreeLevelTraversal {
             var level: [Int] = []
             let size = queue.size()
             for _ in 0 ..< size {
-                let head = queue.dequeue()
-                level.append(head!.val)
                 
-                if let left = head!.left {
+                guard let head = queue.dequeue() else {
+                    preconditionFailure("Head is required")
+                }
+                
+                level.append(head.val)
+                
+                if let left = head.left {
                     queue.enqueue(left)
                 }
                 
-                if let right = head!.right {
+                if let right = head.right {
                     queue.enqueue(right)
                 }
             }


### PR DESCRIPTION
- Removed implicitly unwrapped optional from LCDepthTree and LCTreeLevelTraversal by using guard let
